### PR TITLE
update filterMaf after djerba plugin updated

### DIFF
--- a/mutect2Consensus.wdl
+++ b/mutect2Consensus.wdl
@@ -505,61 +505,52 @@ task filterMaf {
 
     for row in df_pl.iterrows():
         hugo_symbol = row[1]['Hugo_Symbol']
-        hgvsp_short = row[1]['HGVSp_Short']
-        hgvsc = row[1]['HGVSc']
-        variant_classification = row[1]["Variant_Classification"]
+        chromosome = row[1]['Chromosome']
+        start_position = row[1]['Start_Position']
+        reference_allele = row[1]['Reference_Allele']
+        allele = row[1]['Allele']
     
         #For normal values
-        if hgvsp_short in df_bc['HGVSp_Short'].values  and not pd.isna(hgvsp_short):
+        # Lookup the entry in the BC
+        row_lookup = df_bc[(df_bc['Hugo_Symbol'] == hugo_symbol) & 
+                                (df_bc['Chromosome'] == chromosome) & 
+                                (df_bc['Start_Position'] == start_position) &
+                                (df_bc['Reference_Allele'] == reference_allele) &
+                                (df_bc['Allele'] == allele)]
 
-            row_lookup = df_bc[(df_bc['Hugo_Symbol'] == hugo_symbol) & 
-                          (df_bc['HGVSc'] == hgvsc) & 
-                          (df_bc['HGVSp_Short'] == hgvsp_short)]
-            if len(row_lookup) == 1:
-                df_pl.at[row[0], "n_depth"] = row_lookup['n_depth'].item()
-                df_pl.at[row[0], "n_ref_count"] = row_lookup['n_ref_count'].item()
-                df_pl.at[row[0], "n_alt_count"] = row_lookup['n_alt_count'].item()
-            else:
-                df_pl.at[row[0], "n_alt_count"] = 5 # filter it out
+        # If there's only one entry, take its normal values
+        if len(row_lookup) == 1:
+            df_pl.at[row[0], "n_depth"] = row_lookup['n_depth'].item()
+            df_pl.at[row[0], "n_ref_count"] = row_lookup['n_ref_count'].item()
+            df_pl.at[row[0], "n_alt_count"] = row_lookup['n_alt_count'].item()
         
-        elif hgvsp_short not in df_bc.index and not pd.isna(hgvsp_short):
+        # If the entry isn't in the table, 
+        # or if there is more than one value and so you can't choose which normal values to take, 
+        # set them as 0
+        else:
             df_pl.at[row[0], "n_depth"] = 0
             df_pl.at[row[0], "n_ref_count"] = 0
             df_pl.at[row[0], "n_alt_count"] = 0
-
-        # Note: splice sites almost always have NA as their HGVSp_Short name. So, compare their HGVSc names instead.
-        elif "splice" in variant_classification.lower(): 
-            row_lookup = df_bc[(df_bc['Hugo_Symbol'] == hugo_symbol) & 
-                                (df_bc['HGVSc'] == hgvsc)]
-            if len(row_lookup) == 1: # there should only be one entry for one gene
-                df_pl.at[row[0], "n_depth"] = row_lookup['n_depth'].item()
-                df_pl.at[row[0], "n_ref_count"] = row_lookup['n_ref_count'].item()
-                df_pl.at[row[0], "n_alt_count"] = row_lookup['n_alt_count'].item()
-            else: # if there are either no entries or more than one entry for one gene, tag it to be filtered out downstream
-                df_pl.at[row[0], "n_alt_count"] = 5
-        
-        else:
-            df_pl.at[row[0], "n_alt_count"] = 5 # for all other cases, tag it to be filtered out downstream
           
         # For frequency values
         
         row_lookup = df_freq[(df_freq['Start_Position'] == row[1]['Start_Position']) &
-                          (df_freq['Reference_Allele'] == row[1]['Reference_Allele']) &
-                          ((df_freq['Tumor_Seq_Allele'] == row[1]['Tumor_Seq_Allele1']) |
-                          (df_freq['Tumor_Seq_Allele'] == row[1]['Tumor_Seq_Allele2']))]
+                            (df_freq['Reference_Allele'] == row[1]['Reference_Allele']) &
+                            ((df_freq['Tumor_Seq_Allele'] == row[1]['Tumor_Seq_Allele1']) |
+                            (df_freq['Tumor_Seq_Allele'] == row[1]['Tumor_Seq_Allele2']))]
 
         if len(row_lookup) > 0:
             df_pl.at[row[0], 'Freq'] = row_lookup['Freq'].item()
         else:
             df_pl.at[row[0], 'Freq'] = 0
-
+    
     for row in df_pl.iterrows():
         hugo_symbol = row[1]['Hugo_Symbol']
         frequency = row[1]['Freq']
         n_alt_count = row[1]['n_alt_count']
         gnomAD_AF = row[1]['gnomAD_AF']
         if hugo_symbol not in GENES_TO_KEEP or frequency > 0.1 or n_alt_count > 4 or gnomAD_AF > 0.001:
-            df_pl = df_pl.drop(row[0])  
+            df_pl = df_pl.drop(row[0])   
 
     df_pl.to_csv(output_path_prefix + '_filtered_maf_for_tar.maf.gz', sep = "\t", compression='gzip', index=False)
 


### PR DESCRIPTION
Please look beyond this pull request as most of the files are in master branch.
Notes for review:
* The wdl will run mutect2 9 times (for tumor, normal and T/N pair, each with three partitioned bam inputs from umiConsensus), which have been parellelized for performance
* The filterMaf task intergreted djerba plugin: https://github.com/oicr-gsi/djerba/blob/GCGI-806_v1.0.0-dev/src/lib/djerba/plugins/tar/snv_indel/plugin.py, but only the fileter_maf__for_tar function, after discussed with Aqsa.
* Two lists in filterMaf probabaly need update in the future: GENES_TO_KEEP and tar_constants.FREQUENCY_FILE, the best way to do this in shesmu probabaly is create shesmu function
* "inputIntervalsToParalellizeBy" does not includes chrM, because some "intervalFile" may not include this in interval, so any data in chrM will be ignored. We could in wdl check the intervalFile first but the wdl gets complicated.

