### PR TITLE
supplying optional argument normalName to vep

### DIFF
--- a/mutect2Consensus.wdl
+++ b/mutect2Consensus.wdl
@@ -212,6 +212,7 @@ workflow mutect2Consensus {
         vcfIndex = matchedAnnotation.annotatedCombinedIndex,
         toMAF = true,
         onlyTumor = false,
+        normalName = normalName,
         tumorOnlyAlign_updateTagValue = true,
         vcf2maf_retainInfoProvided = true,
         vep_referenceFasta = resources[reference].inputRefFasta,


### PR DESCRIPTION
Adding normalName to vep for the matched T/N case, to provide info for vcf2maf.
Described in https://jira.oicr.on.ca/browse/GRD-683