### PR TITLE
remove targetbed input in vep

### DIFF
--- a/mutect2Consensus.wdl
+++ b/mutect2Consensus.wdl
@@ -100,7 +100,6 @@ workflow mutect2Consensus {
         onlyTumor = true,
         tumorOnlyAlign_updateTagValue = true,
         vcf2maf_retainInfoProvided = true,
-        targetBed = intervalFile,
         tumorName = ig.outputFileNamePrefix,
         reference = reference
     }


### PR DESCRIPTION
Aqsa: I think the removed line is a bug, and it is the reason you see the tumor only version and matached version have different genes.